### PR TITLE
Add missing config option for command_prefix

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -3,3 +3,6 @@
 
 # The token for the bot.
 token: mfa.exampletoken
+
+# The command prefix used by the bot.
+command_prefix: '!!'


### PR DESCRIPTION
Add missing configuration option for specifying the command prefix of
the bot.