### PR TITLE
Add basic cog settings API.

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,5 +1,12 @@
-## This is an example configuration file for the bot.
+## This is an example configuration file for the bot in standalone mode.
 ## Make sure to edit it prior to using it.
+
+# Don't change this.
+# This boots the bot in standalone mode and not as a bot node.
+standalone: true
+
+# If this bot is in development mode.
+dev: true
 
 # The token for the bot.
 token: mfa.exampletoken

--- a/union/core/bot.py
+++ b/union/core/bot.py
@@ -72,6 +72,33 @@ class Union(commands.AutoShardedBot):
 
             return default
 
+    async def set_config(self, realm: str, key: str, value: str):
+        """
+        Sets a config value.
+
+        :param realm: The realm of storage (usually the cog name).
+            Passing None will use internal configuration (usually not needed).
+
+        :param key: The config key to set.
+        :param value: The value to set.
+        """
+        if self.standalone:
+            if self.dev:
+                config_data = pathlib.Path("cog-config-dev.json")
+            else:
+                config_data = pathlib.Path("cog-config.json")
+
+            data = json.loads(config_data.read_text())
+            try:
+                data[realm][key] = value
+            except KeyError:
+                data[realm] = {key: value}
+
+            dumped = json.dumps(data)
+            config_data.write_text(dumped, encoding='utf-8')
+        else:
+            raise NotImplementedError
+
     async def on_command_error(self, context: Context, exception: CommandError):
         """
         Handles non-fatal command errors.

--- a/union/core/bot.py
+++ b/union/core/bot.py
@@ -16,7 +16,7 @@ class Union(commands.AutoShardedBot):
     """
     The core bot class.
     """
-    _no_default = object()
+    no_default = object()
 
     def __init__(self, config: dict):
         #: The current bot's internal config.
@@ -42,7 +42,7 @@ class Union(commands.AutoShardedBot):
     def __del__(self):
         self.session.close()
 
-    async def get_config(self, realm: str, key: str, *, default: typing.Any = _no_default):
+    async def get_config(self, realm: str, key: str, *, default: typing.Any = no_default):
         """
         Gets a config value.
 
@@ -67,7 +67,7 @@ class Union(commands.AutoShardedBot):
             return data[realm][key]
         except KeyError:
             # check for sentinel instead of None as default
-            if default is self._no_default:
+            if default is self.no_default:
                 raise
 
             return default

--- a/union/core/cog.py
+++ b/union/core/cog.py
@@ -1,0 +1,27 @@
+"""
+Custom super class for all cogs.
+"""
+from union.core.bot import Union
+
+
+class Cog(object):
+    """
+    A custom superclass for all cogs. This provides some valuable things to cog subclasses.
+    """
+    def __init__(self, bot: Union):
+        self.bot = bot
+
+    async def get_config(self, key: str, *, default: Union.no_default):
+        """
+        Gets a config key for the current cog's config storage.
+        """
+        return await self.bot.get_config(realm=self.__class__.__name__, key=key,
+                                         default=default)
+
+    @classmethod
+    def setup(cls, bot: Union):
+        """
+        Sets up the current cog.
+        """
+        instance = cls(bot)
+        bot.add_cog(instance)

--- a/union/core/core.py
+++ b/union/core/core.py
@@ -6,18 +6,18 @@ import traceback
 import discord
 from discord.ext import commands
 
+from union.core.cog import Cog
+from union.core.context import Context
 
-class Core:
+
+class Core(Cog):
     """
     Core features of the bot.
     """
 
-    def __init__(self, bot):
-        self.bot = bot
-
     @commands.group(invoke_without_command=True)
     @commands.is_owner()
-    async def change(self, ctx):
+    async def change(self, ctx: Context):
         """
         Change the looks of the bot.
         """
@@ -25,7 +25,7 @@ class Core:
 
     @change.command(aliases=["username"])
     @commands.is_owner()
-    async def name(self, ctx, *, username: commands.clean_content):
+    async def name(self, ctx: Context, *, username: commands.clean_content):
         """
         Change the username of the bot.
         """
@@ -34,7 +34,7 @@ class Core:
 
     @change.command(aliases=['playing'])
     @commands.is_owner()
-    async def game(self, ctx, *, message: commands.clean_content):
+    async def game(self, ctx: Context, *, message: commands.clean_content):
         """
         Change the game of the bot.
         """
@@ -43,7 +43,7 @@ class Core:
 
     @change.command()
     @commands.is_owner()
-    async def status(self, ctx, *, status):
+    async def status(self, ctx: Context, *, status):
         """
         Change the status of the bot.
         """
@@ -52,7 +52,7 @@ class Core:
 
     @change.command(aliases=["avy"])
     @commands.is_owner()
-    async def avatar(self, ctx, url: str = None):
+    async def avatar(self, ctx: Context, url: str = None):
         """
         Change the avatar of the bot.
 
@@ -79,7 +79,7 @@ class Core:
 
     @commands.command(aliases=['eval'])
     @commands.is_owner()
-    async def debug(self, ctx, *, code: str):
+    async def debug(self, ctx: Context, *, code: str):
         """
         Run code.
         """
@@ -107,7 +107,7 @@ class Core:
 
     @commands.command()
     @commands.is_owner()
-    async def quit(self, ctx):
+    async def quit(self, ctx: Context):
         """
         Shut off the bot.
         """
@@ -115,5 +115,4 @@ class Core:
         await ctx.bot.logout()
 
 
-def setup(bot):
-    bot.add_cog(Core(bot))
+setup = Core.setup


### PR DESCRIPTION
This is provisional, but provides a single function to get a setting. It can be edited to call from the backend without breaking any of the rest of the bot.